### PR TITLE
RSP-3938: Incorrect role name in audit history

### DIFF
--- a/src/Infrastructure/Rsp.UsersService.Infrastructure/Helpers/UserRoleAuditTrailHandler.cs
+++ b/src/Infrastructure/Rsp.UsersService.Infrastructure/Helpers/UserRoleAuditTrailHandler.cs
@@ -25,7 +25,7 @@ public class UserRoleAuditTrailHandler : IAuditTrailHandler
                 var addAuditTrail = new UserAuditTrail()
                 {
                     DateTimeStamp = DateTime.UtcNow,
-                    Description = $"{user!.Email} was assigned {role!.Name} role",
+                    Description = $"{user!.Email} was assigned {role!.Name!.Replace('_', ' ')} role",
                     UserId = user!.Id,
                     SystemAdministratorId = systemAdmin.Id
                 };

--- a/tests/UnitTests/Rsp.UsersService.UnitTests/HelpersTests/UserRoleAuditTrailHandlerTests.cs
+++ b/tests/UnitTests/Rsp.UsersService.UnitTests/HelpersTests/UserRoleAuditTrailHandlerTests.cs
@@ -91,7 +91,7 @@ public class UserRoleAuditTrailHandlerTests
         // Assert
         var auditTrail = result.Single();
 
-        auditTrail.Description.ShouldBe("test@example.com was assigned system_administrator role");
+        auditTrail.Description.ShouldBe("test@example.com was assigned system administrator role");
         auditTrail.UserId.ShouldBe("user1");
         auditTrail.SystemAdministratorId.ShouldBe("admin1");
     }


### PR DESCRIPTION
## What was the purpose of this ticket?

Fix incorrect role name in audit history

## Jira Ref

[RSP-3938](https://nihr.atlassian.net/browse/RSP-3938)

## Type of Change

Put [X] inside the [] to make the box ticked

- [] New feature
- [] Refactoring
- [x] Bug-fix
- [] DevOps
- [] Testing
